### PR TITLE
Ensure your App Service is accessible via HTTPS only

### DIFF
--- a/quickstart/201-web-app-postgres-keyvault/webapp.tf
+++ b/quickstart/201-web-app-postgres-keyvault/webapp.tf
@@ -22,4 +22,5 @@ resource "azurerm_app_service" "webAppFrontend" {
     type  = "MySql"
     value = "Database=${azurerm_mysql_database.webAppBackend.name};Data Source=${azurerm_mysql_server.webAppBackend.fqdn};User Id=${var.administratorLogin}@${azurerm_mysql_server.webAppBackend.name};Password=${var.administratorLoginPassword}"
   }
+  https_only = true
 }


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

It is better to configure your App Service to be accessible via HTTPS only. By default, both HTTP and HTTPS are available.

